### PR TITLE
feat: add get admin by auth id rpc

### DIFF
--- a/supabase/migrations/20250815000000_get_admin_by_auth_id.sql
+++ b/supabase/migrations/20250815000000_get_admin_by_auth_id.sql
@@ -1,0 +1,12 @@
+-- Return admin user row for a given Auth user id
+CREATE OR REPLACE FUNCTION public.get_admin_by_auth_id(auth_user_id uuid)
+RETURNS admin_users
+LANGUAGE sql STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT *
+  FROM public.admin_users
+  WHERE auth_user_id = get_admin_by_auth_id.auth_user_id
+  LIMIT 1;
+$$;


### PR DESCRIPTION
## Summary
- add migration exposing `get_admin_by_auth_id` RPC

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx supabase db push` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_689d9c74ecdc832eab911f986e7a8b75